### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,3 +6,9 @@ build:
     python: "3.8"
     
 sphinx.fail_on_warning
+
+python:
+  # Install our python package before building the docs
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
Adding the following to fix verbose logging issue.

 "python:
  # Install our python package before building the docs
  install:
    - method: pip
      path: ."